### PR TITLE
Print newline for last bit of encoded data

### DIFF
--- a/src/Ecoji/Ecoji.cs
+++ b/src/Ecoji/Ecoji.cs
@@ -127,9 +127,12 @@ public static partial class Ecoji
                     break;
             }
 
-            if (read <= 0)
+            if (read <= 0) {
+                if (wrapLineProgress > 0)
+                    output.WriteLine();
                 break;
-
+            }
+            
             for (var i = read; i < b.Length; i++)
                 b[i] = 0;
 


### PR DESCRIPTION
While experimenting with this I noticed the following difference.  I think this change makes them consistent.

```
keith@et:~/git/dotnet-ecoji$ echo -n abc | ecoji
👖📸🎈☕
$ echo -n abc | dotnet run -p src/Ecoji.CommandLineTool
👖📸🎈☕keith@et:~/git/dotnet-ecoji$
```